### PR TITLE
feat: add support for prNumber input to allow closing of specific PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
 | `token` | `GITHUB_TOKEN` or a `repo` scoped [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). | `GITHUB_TOKEN` |
 | `repository` | The GitHub repository containing the pull request. | `github.repository` (Current repository) |
 | `comment` | A comment to make on the pull request before closing. | |
+| `pr-number` | Target PR number | |
 
 ### Accessing pull requests in other repositories
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,8 @@ inputs:
     default: ${{ github.repository }}
   comment:
     description: 'A comment to make on the pull requests before closing'
+  pr-number:
+    description: 'Target PR number'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
+import {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods'
 import {inspect} from 'util'
 
 function getErrorMessage(error: unknown) {
@@ -12,7 +13,8 @@ async function run(): Promise<void> {
     const inputs = {
       token: core.getInput('token'),
       repository: core.getInput('repository'),
-      comment: core.getInput('comment')
+      comment: core.getInput('comment'),
+      prNumber: Number(core.getInput('pr-number'))
     }
     core.debug(`Inputs: ${inspect(inputs)}`)
 
@@ -21,11 +23,25 @@ async function run(): Promise<void> {
 
     const octokit = github.getOctokit(inputs.token)
 
-    const {data: pulls} = await octokit.rest.pulls.list({
-      owner: owner,
-      repo: repo,
-      state: 'open'
-    })
+    let pulls:
+      | RestEndpointMethodTypes['pulls']['list']['response']['data']
+      | RestEndpointMethodTypes['pulls']['get']['response']['data'][]
+
+    if (Number.isInteger(inputs.prNumber) && inputs.prNumber > 0) {
+      const {data: pull} = await octokit.rest.pulls.get({
+        owner,
+        repo,
+        pull_number: inputs.prNumber
+      })
+      pulls = [pull]
+    } else {
+      const {data} = await octokit.rest.pulls.list({
+        owner: owner,
+        repo: repo,
+        state: 'open'
+      })
+      pulls = data
+    }
     core.debug(`Pulls: ${inspect(pulls)}`)
 
     let closedCount = 0


### PR DESCRIPTION
Add the `pr-number` flag to check if a particular PR is a fork pull.

This can be used as follows.
```
on:
  pull_request:
    types: [opened, reopened]

jobs:
  rebase:
    runs-on: ubuntu-latest
    steps:
      - name: Close Pull
        uses: peter-evans/close-fork-pulls@v3
        with:
          pr-number: ${{ github.event.pull_request.number }}
```